### PR TITLE
Validate session names to contain only letters, numbers, and dashes

### DIFF
--- a/src/components/LoginPage.vue
+++ b/src/components/LoginPage.vue
@@ -21,7 +21,13 @@
             <input class="login-input" id="room" type="text" required v-model="session" />
           </div>
         </div>
-        <p v-if="session && session.trim().length > 0 && !isValidSession" class="mt-2 text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
+        <div class="flex items-center mt-6">
+          <div class="w-1/4">
+          </div>
+          <div class="w-3/4">
+            <p v-if="session && session.trim().length > 0 && !isValidSession" class="mt-2 text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
+          </div>
+        </div>
         <div class="flex items-center mt-6">
           <div class="w-1/4"></div>
           <div class="w-3/4">

--- a/src/components/LoginPage.vue
+++ b/src/components/LoginPage.vue
@@ -24,12 +24,13 @@
         <div class="flex items-center">
           <div class="w-1/4"></div>
           <div class="w-3/4">
-            <router-link v-if="(session.trim().length > 0) && (name.trim().length > 0)" :to="{ name: 'SessionPage', params: { id: session.toLowerCase().trim(), name } }" tag="button" class="btn btn-blue no-underline">
+            <router-link v-if="isValidSession && (name.trim().length > 0)" :to="{ name: 'SessionPage', params: { id: session.toLowerCase().trim(), name } }" tag="button" class="btn btn-blue no-underline">
               Join
             </router-link>
             <button v-else class="btn btn-blue hover:bg-blue-400 dark:hover:bg-blue-700 opacity-50 cursor-not-allowed" disabled>
               Join
             </button>
+            <p v-if="!isValidSession" class="text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
           </div>
         </div>
       </form>
@@ -44,6 +45,11 @@ export default {
     return {
       session: '',
       name: ''
+    }
+  },
+  computed: {
+    isValidSession() {
+      return /^[a-zA-Z0-9-]+$/.test(this.session);
     }
   },
   mounted () {

--- a/src/components/LoginPage.vue
+++ b/src/components/LoginPage.vue
@@ -21,11 +21,11 @@
             <input class="login-input" id="room" type="text" required v-model="session" />
           </div>
         </div>
-        <div class="flex items-center mt-6">
+        <div v-if="session && session.trim().length > 0 && !isValidSession" class="flex items-center mt-2">
           <div class="w-1/4">
           </div>
           <div class="w-3/4">
-            <p v-if="session && session.trim().length > 0 && !isValidSession" class="mt-2 text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
+            <p class="text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
           </div>
         </div>
         <div class="flex items-center mt-6">

--- a/src/components/LoginPage.vue
+++ b/src/components/LoginPage.vue
@@ -5,7 +5,7 @@
     </nav>
     <main>
       <form class="px-4 py-6 max-w-md mx-auto">
-        <div class="flex items-center mb-6">
+        <div class="flex items-center">
           <div class="w-1/4">
             <label for="name" class="block font-bold text-right pr-4 text-gray-500">Name</label>
           </div>
@@ -13,16 +13,16 @@
             <input class="login-input" id="name" type="text" required v-model="name" />
           </div>
         </div>
-        <div class="flex items-center mb-6">
+        <div class="flex items-center mt-6">
           <div class="w-1/4">
             <label for="room" class="block text-gray-500 font-bold text-right pr-4">Room</label>
           </div>
           <div class="w-3/4">
             <input class="login-input" id="room" type="text" required v-model="session" />
-            <p v-if="session && session.trim().length > 0 && !isValidSession" class="text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
           </div>
         </div>
-        <div class="flex items-center">
+        <p v-if="session && session.trim().length > 0 && !isValidSession" class="mt-2 text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
+        <div class="flex items-center mt-6">
           <div class="w-1/4"></div>
           <div class="w-3/4">
             <router-link v-if="isValidSession && isValidName" :to="{ name: 'SessionPage', params: { id: session.toLowerCase().trim(), name } }" tag="button" class="btn btn-blue no-underline">

--- a/src/components/LoginPage.vue
+++ b/src/components/LoginPage.vue
@@ -19,18 +19,18 @@
           </div>
           <div class="w-3/4">
             <input class="login-input" id="room" type="text" required v-model="session" />
+            <p v-if="session && session.trim().length > 0 && !isValidSession" class="text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
           </div>
         </div>
         <div class="flex items-center">
           <div class="w-1/4"></div>
           <div class="w-3/4">
-            <router-link v-if="isValidSession && (name.trim().length > 0)" :to="{ name: 'SessionPage', params: { id: session.toLowerCase().trim(), name } }" tag="button" class="btn btn-blue no-underline">
+            <router-link v-if="isValidSession && isValidName" :to="{ name: 'SessionPage', params: { id: session.toLowerCase().trim(), name } }" tag="button" class="btn btn-blue no-underline">
               Join
             </router-link>
             <button v-else class="btn btn-blue hover:bg-blue-400 dark:hover:bg-blue-700 opacity-50 cursor-not-allowed" disabled>
               Join
             </button>
-            <p v-if="!isValidSession" class="text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
           </div>
         </div>
       </form>
@@ -49,7 +49,10 @@ export default {
   },
   computed: {
     isValidSession() {
-      return /^[a-zA-Z0-9-]+$/.test(this.session);
+      return /^[a-zA-Z0-9-]+$/.test(this.session.trim());
+    },
+    isValidName() {
+      return this.name.trim().length > 0;
     }
   },
   mounted () {

--- a/src/components/NotFound.vue
+++ b/src/components/NotFound.vue
@@ -9,8 +9,9 @@
 
     <form class="mt-8 self-center flex">
       <input type="text" id="room" class="login-input w-48 rounded-r-none" v-model="id" placeholder="session-id">
-      <router-link v-if="id && id.trim().length > 0" :to="{ name: 'SessionPage', params: { id: id.trim() } }" tag="button" class="btn btn-blue no-underline rounded-l-none">join</router-link>
+      <router-link v-if="isValidSession && id && id.trim().length > 0" :to="{ name: 'SessionPage', params: { id: id.trim() } }" tag="button" class="btn btn-blue no-underline rounded-l-none">join</router-link>
       <button v-else class="btn btn-blue opacity-50 hover:bg-blue-500 cursor-not-allowed rounded-l-none" disabled>join</button>
+      <p v-if="!isValidSession" class="text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
     </form>
   </div>
 </template>
@@ -25,6 +26,11 @@ export default {
   data () {
     return {
       id: ''
+    }
+  },
+  computed: {
+    isValidSession() {
+      return /^[a-zA-Z0-9-]+$/.test(this.id);
     }
   }
 }

--- a/src/components/NotFound.vue
+++ b/src/components/NotFound.vue
@@ -9,10 +9,10 @@
 
     <form class="mt-8 self-center flex">
       <input type="text" id="room" class="login-input w-48 rounded-r-none" v-model="id" placeholder="session-id">
-      <p v-if="id && id.trim().length > 0 && !isValidSession" class="text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
       <router-link v-if="isValidSession" :to="{ name: 'SessionPage', params: { id: id.trim() } }" tag="button" class="btn btn-blue no-underline rounded-l-none">join</router-link>
       <button v-else class="btn btn-blue opacity-50 hover:bg-blue-500 cursor-not-allowed rounded-l-none" disabled>join</button>
     </form>
+    <p v-if="id && id.trim().length > 0 && !isValidSession" class="mt-2 text-red-500 text-xs text-center italic">Session name can only contain letters, numbers, and dashes.</p>
   </div>
 </template>
 

--- a/src/components/NotFound.vue
+++ b/src/components/NotFound.vue
@@ -9,9 +9,9 @@
 
     <form class="mt-8 self-center flex">
       <input type="text" id="room" class="login-input w-48 rounded-r-none" v-model="id" placeholder="session-id">
-      <router-link v-if="isValidSession && id && id.trim().length > 0" :to="{ name: 'SessionPage', params: { id: id.trim() } }" tag="button" class="btn btn-blue no-underline rounded-l-none">join</router-link>
+      <p v-if="id && id.trim().length > 0 && !isValidSession" class="text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
+      <router-link v-if="isValidSession" :to="{ name: 'SessionPage', params: { id: id.trim() } }" tag="button" class="btn btn-blue no-underline rounded-l-none">join</router-link>
       <button v-else class="btn btn-blue opacity-50 hover:bg-blue-500 cursor-not-allowed rounded-l-none" disabled>join</button>
-      <p v-if="!isValidSession" class="text-red-500 text-xs italic">Session name can only contain letters, numbers, and dashes.</p>
     </form>
   </div>
 </template>
@@ -30,7 +30,7 @@ export default {
   },
   computed: {
     isValidSession() {
-      return /^[a-zA-Z0-9-]+$/.test(this.id);
+      return /^[a-zA-Z0-9-]+$/.test(this.id.trim());
     }
   }
 }


### PR DESCRIPTION
Related to #17

Implements input validation for session names in `LoginPage.vue` and `NotFound.vue` to ensure they only contain letters, numbers, and dashes.

- Adds a computed property `isValidSession` in both components to validate session names using a regex pattern.
- Conditions the "Join" button to be enabled only if the session name is valid and other required fields are filled.
- Displays an error message when the session name contains invalid characters, guiding the user to input a correct format.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nathanheffley/pointer/issues/17?shareId=e996520c-e518-4206-9cc5-4272261ce11d).