### PR TITLE
Disable voting inputs when offline

### DIFF
--- a/src/components/SessionPage.vue
+++ b/src/components/SessionPage.vue
@@ -21,6 +21,7 @@
           v-on:pass="passVote()"
           :show-pass-instructional="showPassInstructional"
           v-on:dismiss-pass-instructional="dismissPassInstructional"
+          :enabled="online"
         ></vote-recorder>
 
         <div class="sm:flex sm:justify-between">
@@ -32,8 +33,8 @@
           <div class="mt-6 text-gray-800">
             <vote-results :votes="votes" :show="showVotes" v-on:hovering="highlightVoters"></vote-results>
 
-            <conditional-button :enabled="(votes.filter(vote => vote !== null).length > 0) && !showVotes" @click="revealVotes">Reveal</conditional-button>
-            <conditional-button :enabled="votes.filter(vote => vote !== null).length > 0" @click="clearVotes">Clear</conditional-button>
+            <conditional-button :enabled="(votes.filter(vote => vote !== null).length > 0) && !showVotes && online" @click="revealVotes">Reveal</conditional-button>
+            <conditional-button :enabled="votes.filter(vote => vote !== null).length > 0 && online" @click="clearVotes">Clear</conditional-button>
           </div>
         </div>
       </div>

--- a/src/components/VoteRecorder.vue
+++ b/src/components/VoteRecorder.vue
@@ -1,14 +1,14 @@
 <template>
   <div>
     <ul class="btn-list sm:max-w-xs">
-      <li><button value="0" @click="recordVote(0)" :class="[ isVote(0) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">0</button></li>
-      <li><button value="1" @click="recordVote(1)" :class="[ isVote(1) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">1</button></li>
-      <li><button value="2" @click="recordVote(2)" :class="[ isVote(2) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">2</button></li>
-      <li><button value="3" @click="recordVote(3)" :class="[ isVote(3) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">3</button></li>
-      <li><button value="5" @click="recordVote(5)" :class="[ isVote(5) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">5</button></li>
-      <li><button value="8" @click="recordVote(8)" :class="[ isVote(8) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">8</button></li>
-      <li><button value="13" @click="recordVote(13)" :class="[ isVote(13) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">13</button></li>
-      <li><button value="?" @click="recordVote('?')" :class="[ isVote('?') ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">?</button></li>
+      <li><button :disabled="!enabled" value="0" @click="recordVote(0)" :class="[ isVote(0) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">0</button></li>
+      <li><button :disabled="!enabled" value="1" @click="recordVote(1)" :class="[ isVote(1) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">1</button></li>
+      <li><button :disabled="!enabled" value="2" @click="recordVote(2)" :class="[ isVote(2) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">2</button></li>
+      <li><button :disabled="!enabled" value="3" @click="recordVote(3)" :class="[ isVote(3) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">3</button></li>
+      <li><button :disabled="!enabled" value="5" @click="recordVote(5)" :class="[ isVote(5) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">5</button></li>
+      <li><button :disabled="!enabled" value="8" @click="recordVote(8)" :class="[ isVote(8) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">8</button></li>
+      <li><button :disabled="!enabled" value="13" @click="recordVote(13)" :class="[ isVote(13) ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">13</button></li>
+      <li><button :disabled="!enabled" value="?" @click="recordVote('?')" :class="[ isVote('?') ? 'btn-blue' : 'btn-gray', 'btn text-xl w-16' ]">?</button></li>
     </ul>
     <div class="mt-2 sm:max-w-xs">
       <Instructional
@@ -20,8 +20,8 @@
         This is helpful so somebody doesn't have to reveal the vote every round.
       </Instructional>
       <div class="flex justify-between">
-        <button @click="passVote()" class="italic text-blue-600 dark:text-blue-400">Pass</button>
-        <button @click="recordVote(null)" class="italic text-gray-600 dark:text-gray-400">Clear your vote...</button>
+        <button :disabled="!enabled" @click="passVote()" class="italic text-blue-600 dark:text-blue-400">Pass</button>
+        <button :disabled="!enabled" @click="recordVote(null)" class="italic text-gray-600 dark:text-gray-400">Clear your vote...</button>
       </div>
     </div>
   </div>
@@ -32,7 +32,7 @@ import Instructional from './Instructional.vue'
 export default {
   components: { Instructional },
   name: 'VoteRecorder',
-  props: ['value', 'showPassInstructional'],
+  props: ['value', 'showPassInstructional', 'enabled'],
   methods: {
     isVote: function (points) {
       if (this.value === null) return true


### PR DESCRIPTION
Fixes #45

Disable voting inputs and clear/reveal buttons when offline.

* **SessionPage.vue**
  - Add `enabled` prop to `VoteRecorder` component and set it to `online`.
  - Update `ConditionalButton` components to include `online` state in the `enabled` prop.
* **VoteRecorder.vue**
  - Add `enabled` prop to the component.
  - Disable voting buttons and pass/clear buttons if `enabled` prop is not truthy.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nathanheffley/pointer/issues/45?shareId=597cbe2b-a31f-430c-b487-69b04e1f4e11).